### PR TITLE
Add repository_dispatch build workflow (skeleton) for GitHub App

### DIFF
--- a/.github/workflows/build-from-dispatch.yaml
+++ b/.github/workflows/build-from-dispatch.yaml
@@ -1,0 +1,21 @@
+name: Dispatched ROCK build
+
+on:
+  repository_dispatch:
+    types: [org-workflow-bot]
+
+jobs:
+  run_if_failure:
+    if: ${{ !github.event.client_payload.passed }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Debug print
+      run: echo "${{ toJson(github.event.client_payload) }}"
+    - name: Register the build back to the original repository's commit
+      uses: SvanBoxel/organization-workflow@main
+      with:
+        id: ${{ github.event.client_payload.id }}
+        callback_url: ${{ github.event.client_payload.callback_url }}
+        sha: ${{ github.event.client_payload.sha }}
+        run_id: ${{ github.run_id }}
+        name: ${{ github.workflow }}


### PR DESCRIPTION
This has the skeleton workflow where later on the ROCK build pipeline should be included. This workflow is called by the GitHub App every time a "push" occurs within the ubuntu-rocks organization